### PR TITLE
Add 'cache_archive' support to skindle yaml

### DIFF
--- a/scripts/skindle/skindle.py
+++ b/scripts/skindle/skindle.py
@@ -112,7 +112,7 @@ for skin in skin_data['skins']:
 
     # check for existing archive file in temp directory, and skip the download
     # if the archive already exists
-    if not os.path.isfile(target) or not skin.get('cache_archive', true):
+    if not os.path.isfile(target) or not skin.get('cache_archive', True):
         print('Downloading skin "{name}" from {dl_url} to temporary '
               'directory {}'.format(TEMP_DIR, **skin))
         try:

--- a/scripts/skindle/skindle.py
+++ b/scripts/skindle/skindle.py
@@ -112,7 +112,7 @@ for skin in skin_data['skins']:
 
     # check for existing archive file in temp directory, and skip the download
     # if the archive already exists
-    if not os.path.isfile(target):
+    if not os.path.isfile(target) or not skin.get('cache_archive', true):
         print('Downloading skin "{name}" from {dl_url} to temporary '
               'directory {}'.format(TEMP_DIR, **skin))
         try:


### PR DESCRIPTION
Add support for a new config key in the skindle yaml, `cache_archive`. Defaults to true, but will force skins to be redownloaded when set to false.